### PR TITLE
Add missing requires.

### DIFF
--- a/ac-haskell-process.el
+++ b/ac-haskell-process.el
@@ -57,6 +57,8 @@
 
 ;;; Code:
 
+(require 'auto-complete)
+(require 'haskell)
 (require 'haskell-process)
 
 


### PR DESCRIPTION
`auto-complete` is required to silence the warnings about free variables.
`haskell` is required for the `haskell-process` function.
